### PR TITLE
Update get_aws_session() to support aws profile

### DIFF
--- a/datasets/tests/utils/test_partitions.py
+++ b/datasets/tests/utils/test_partitions.py
@@ -51,7 +51,7 @@ def test_get_path_partitions_suffix(data_path: Path, assume_role: str):
 def test_load_partitions_s3(assume_role: str, region_partitioned_paths: List[str]):
     bucket_name = "test-bucket"
     path = f"s3://{bucket_name}/data/models/"
-    get_aws_session() # test with default iam role
+    get_aws_session()  # test with default iam role
     s3 = get_aws_client(assume_role, "s3")
     s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "us-west-2"})
     for region_path in region_partitioned_paths:

--- a/datasets/tests/utils/test_partitions.py
+++ b/datasets/tests/utils/test_partitions.py
@@ -51,7 +51,6 @@ def test_get_path_partitions_suffix(data_path: Path, assume_role: str):
 def test_load_partitions_s3(assume_role: str, region_partitioned_paths: List[str]):
     bucket_name = "test-bucket"
     path = f"s3://{bucket_name}/data/models/"
-    get_aws_session()  # test with default iam role
     s3 = get_aws_client(assume_role, "s3")
     s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "us-west-2"})
     for region_path in region_partitioned_paths:

--- a/datasets/tests/utils/test_partitions.py
+++ b/datasets/tests/utils/test_partitions.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 from moto import mock_s3, mock_sts
 
-from datasets.utils.aws import get_aws_session, get_aws_client
+from datasets.utils.aws import get_aws_client
 from datasets.utils.partitions import Partition, get_path_partitions
 
 

--- a/datasets/tests/utils/test_partitions.py
+++ b/datasets/tests/utils/test_partitions.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 from moto import mock_s3, mock_sts
 
-from datasets.utils.aws import get_aws_client
+from datasets.utils.aws import get_aws_session, get_aws_client
 from datasets.utils.partitions import Partition, get_path_partitions
 
 
@@ -51,6 +51,7 @@ def test_get_path_partitions_suffix(data_path: Path, assume_role: str):
 def test_load_partitions_s3(assume_role: str, region_partitioned_paths: List[str]):
     bucket_name = "test-bucket"
     path = f"s3://{bucket_name}/data/models/"
+    get_aws_session() # test with default iam role
     s3 = get_aws_client(assume_role, "s3")
     s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "us-west-2"})
     for region_path in region_partitioned_paths:

--- a/datasets/utils/aws.py
+++ b/datasets/utils/aws.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from typing import Iterable, Optional, Tuple
 from urllib.parse import ParseResult, urlparse
 
@@ -9,7 +8,6 @@ from botocore.credentials import (
     DeferredRefreshableCredentials,
 )
 from botocore.session import Session
-from dateutil.tz import tzlocal
 
 
 _logger = logging.getLogger(__name__)

--- a/datasets/utils/aws.py
+++ b/datasets/utils/aws.py
@@ -20,10 +20,12 @@ def get_aws_session(role_arn: str = None, profile_name: str = None) -> Session:
         profile_name: AWS profile
     Returns: boto3 Session
     """
+    region_name = "us-west-2"
+
     if profile_name:
-        source_session = boto3.Session(profile_name=profile_name)
+        source_session = boto3.Session(profile_name=profile_name, region_name=region_name)
     else:
-        source_session = boto3.Session()
+        source_session = boto3.Session(region_name=region_name)
 
     if role_arn is None:
         return source_session
@@ -44,6 +46,7 @@ def get_aws_session(role_arn: str = None, profile_name: str = None) -> Session:
         aws_access_key_id=credentials.access_key,
         aws_secret_access_key=credentials.secret_key,
         aws_session_token=credentials.token,
+        region_name=region_name,
     )
 
 
@@ -56,12 +59,7 @@ def get_aws_client(role_arn: str, service: str):
     Returns: Returns an AWS client
 
     """
-    if role_arn is None:
-        session = boto3.Session(region_name="us-west-2")
-    else:
-        botocore_session = get_aws_session(role_arn)
-        session = boto3.Session(botocore_session=botocore_session, region_name="us-west-2")
-
+    session = get_aws_session(role_arn)
     return session.client(service)
 
 

--- a/datasets/utils/aws.py
+++ b/datasets/utils/aws.py
@@ -46,6 +46,7 @@ def get_aws_session(role_arn: str = None, profile_name: str = None) -> Session:
         aws_session_token=credentials.token,
     )
 
+
 def get_aws_client(role_arn: str, service: str):
     """
     Args:

--- a/datasets/utils/aws.py
+++ b/datasets/utils/aws.py
@@ -27,7 +27,7 @@ def get_aws_session(role_arn: str = None, profile_name: str = None) -> Session:
 
     if role_arn is None:
         return source_session
-    
+
     # Fetch assumed role's credentials
     fetcher = AssumeRoleCredentialFetcher(
         client_creator=source_session._session.create_client,
@@ -37,16 +37,14 @@ def get_aws_session(role_arn: str = None, profile_name: str = None) -> Session:
 
     # Retrieve crednetials of the assumed role and auto-refresh
     credentials = DeferredRefreshableCredentials(
-        method="assume-role",
-        refresh_using=fetcher.fetch_credentials
+        method="assume-role", refresh_using=fetcher.fetch_credentials
     )
 
     return boto3.Session(
-                         aws_access_key_id=credentials.access_key,
-                         aws_secret_access_key=credentials.secret_key,
-                         aws_session_token=credentials.token
-           )
-
+        aws_access_key_id=credentials.access_key,
+        aws_secret_access_key=credentials.secret_key,
+        aws_session_token=credentials.token,
+    )
 
 def get_aws_client(role_arn: str, service: str):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zdatasets"
-version = "0.0.9.dev1"
+version = "0.0.10"
 description = "Dataset SDK for consistent read/write [batch, online, streaming] data."
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
It supports getting aws session with (1) aws profile (either okta profile via gimme-aws-creds or aws sso profile) (2) assumea specified aws role from the default iam role or given profile.

