### PR TITLE
AIP-6606: Relax upper bound for python to ensure compatibility with other python libraries at ZG

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ hive_dataset = "datasets.plugins:HiveDataset"
 metaflow_executor = "datasets.plugins:MetaflowExecutor"
 
 [tool.poetry.dependencies]
-python = ">=3.9.0,<3.11"
+python = ">=3.9.0,<4"
 pandas = ">=1.4.0"
 pyarrow = ">=6.0.0"
 dask = { version = ">=2021.9.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zdatasets"
-version = "0.1.3"
+version = "0.2.0"
 description = "Dataset SDK for consistent read/write [batch, online, streaming] data."
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
I'm currently trying to get this to resolve within `odp-dataset-plugin` but the `python` range is conflicting. I'm hoping there is no reason we restrict the upper bound so moving to `< 4` given that'd be the increment with breaking, backwards incompatible changes.