### PR TITLE
Serializable SecretFetcher 

### DIFF
--- a/datasets/dataset_plugin.py
+++ b/datasets/dataset_plugin.py
@@ -23,6 +23,13 @@ class StorageOptions:
     def to_json(self) -> dict:
         ret = dataclasses.asdict(self, dict_factory=lambda x: {k: v for (k, v) in x if v is not None})
         ret["type"] = type(self).__name__
+
+        # Overwrite for nested dataclass object e.g. SecretFetcher with to_json defined
+        for field in dataclasses.fields(self):
+            field_obj = getattr(self, field.name)
+            if getattr(field_obj, "to_json", None):
+                ret[field.name] = field_obj.to_json()
+
         return ret
 
 

--- a/datasets/metaflow.py
+++ b/datasets/metaflow.py
@@ -11,6 +11,7 @@ from datasets._typing import ColumnNames
 from datasets.context import Context
 from datasets.dataset_plugin import DatasetPlugin, StorageOptions
 from datasets.mode import Mode
+from datasets.utils.secret_fetcher import SecretFetcher
 
 
 class _DatasetTypeClass(ParamType):
@@ -73,12 +74,17 @@ class _DatasetParamsDecoder(json.JSONDecoder):
 
         return ret
 
-    def object_hook(self, obj: dict) -> Union[_DatasetParams, StorageOptions]:
+    def object_hook(self, obj: dict) -> Union[_DatasetParams, StorageOptions, SecretFetcher]:
         type = obj.get("type")
         if type:
             # remove "type"
             del obj["type"]
 
+            # SecretFetcher type
+            if type == "SecretFetcher":
+                return SecretFetcher(**obj)
+
+            # StorageOptions type
             mapping: Dict[str, Type[StorageOptions]] = {
                 f.__name__.lower(): f for f in _DatasetParamsDecoder.get_storage_subclasses(StorageOptions)
             }

--- a/datasets/tests/test_dataset_plugin.py
+++ b/datasets/tests/test_dataset_plugin.py
@@ -14,7 +14,7 @@ from datasets.tests.conftest import TestExecutor
 from datasets.utils.secret_fetcher import SecretFetcher
 
 
-# We'll need to inherit dict too to make this class Json serializable
+# We'll need to inherit dict too to make this class json serializable
 class _TestPlugin(DatasetPlugin, dict):
     def __init__(
         self,

--- a/datasets/tests/test_metaflow.py
+++ b/datasets/tests/test_metaflow.py
@@ -12,6 +12,11 @@ from datasets.mode import Mode
 from datasets.plugins.batch.batch_base_plugin import BatchOptions
 from datasets.plugins.batch.batch_dataset import BatchDataset
 from datasets.plugins.batch.hive_dataset import HiveOptions
+from datasets.tests.test_dataset_plugin import (
+    SecretDatasetPluginTest,
+    SecretDatasetTestOptions,
+)
+from datasets.utils.secret_fetcher import SecretFetcher
 
 
 def test_dataset_dumps_load():
@@ -28,6 +33,22 @@ def test_dataset_dumps_load():
     assert dataset2.options.partition_by == "foo"
     assert dataset2.mode == Mode.READ_WRITE
     assert isinstance(dataset2, BatchDataset)
+    assert dataset == dataset2
+
+
+def test_dataset_secret_dumps_load():
+    dataset = Dataset(
+        name="TestSecret",
+        mode=Mode.READ_WRITE,
+        options=SecretDatasetTestOptions(secret=SecretFetcher(env_var="test2")),
+    )
+
+    json_value = json.dumps(dataset)
+    dataset2 = _DatasetTypeClass().convert(json_value, None, None)
+
+    assert dataset2.secret.env_var == "test2"
+    assert dataset2.mode == Mode.READ_WRITE
+    assert isinstance(dataset2, SecretDatasetPluginTest)
     assert dataset == dataset2
 
 

--- a/datasets/utils/secret_fetcher.py
+++ b/datasets/utils/secret_fetcher.py
@@ -1,4 +1,5 @@
 import base64
+import dataclasses
 import importlib
 import json
 import logging
@@ -105,6 +106,11 @@ class SecretFetcher:
             return self._fetch_env_secret()
         if self.raw_secret:
             return self._fetch_raw_secret()
+
+    def to_json(self) -> dict:
+        ret = dataclasses.asdict(self, dict_factory=lambda x: {k: v for (k, v) in x if v is not None})
+        ret["type"] = type(self).__name__
+        return ret
 
     def _fetch_kubernetes_secret(self) -> SECRET_RETURN_TYPE:
         kubernetes = try_import_kubernetes()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zdatasets"
-version = "0.2.2.dev1"
+version = "0.2.3"
 description = "Dataset SDK for consistent read/write [batch, online, streaming] data."
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zdatasets"
-version = "0.2.1"
+version = "0.2.2.dev1"
 description = "Dataset SDK for consistent read/write [batch, online, streaming] data."
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
Allow SecretFetcher to be json serializable, so that it can be passed in dynamically through CLI/env var.

- [ ] Update version before merging