### PR TITLE
Allowing older version of pandas to be used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ metaflow_executor = "datasets.plugins:MetaflowExecutor"
 
 [tool.poetry.dependencies]
 python = ">=3.9.0,<4"
-pandas = ">=1.4.0"
+pandas = ">=1.1.0"
 pyarrow = ">=6.0.0"
 dask = { version = ">=2021.9.1", optional = true }
 pyspark = { version = "^3.2.0", optional = true }


### PR DESCRIPTION
As a common lib, it may be easier to have wide dependency ranges. 

This PR is resolving a dependency conflict with zillow project using this repo:
```
There are incompatible versions in the resolved dependencies:
  pandas>=1.4.0 (from zdatasets[kubernetes]==0.2.1->-r requirements.in (line 9))
  pandas==1.3.5 (from floor-map-insights==1.3.9->panoloc==1.0.5->covis-pose==0.1.2->-r requirements.in (line 18))
```